### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/android/app/src/main/java/com/graphhopper/android/AndroidHelper.java
+++ b/android/app/src/main/java/com/graphhopper/android/AndroidHelper.java
@@ -12,6 +12,10 @@ import android.net.NetworkInfo;
 
 public class AndroidHelper
 {
+    private AndroidHelper()
+    {
+    }
+
     public static List<String> readFile( Reader simpleReader ) throws IOException
     {
         BufferedReader reader = new BufferedReader(simpleReader);

--- a/core/src/main/java/com/graphhopper/reader/OSMTagParser.java
+++ b/core/src/main/java/com/graphhopper/reader/OSMTagParser.java
@@ -28,6 +28,9 @@ import javax.xml.datatype.Duration;
  */
 public class OSMTagParser
 {
+    private OSMTagParser() {
+    }
+
     /**
      * Parser according to http://wiki.openstreetmap.org/wiki/Key:duration The value consists of a
      * string ala 'hh:mm', format for hours and minutes 'mm', 'hh:mm' or 'hh:mm:ss', or

--- a/core/src/main/java/com/graphhopper/routing/ch/PrepareEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/PrepareEncoder.java
@@ -30,6 +30,9 @@ public class PrepareEncoder
     private static final long scBwdDir = 0x2;
     private static final long scDirMask = 0x3;
 
+    private PrepareEncoder() {
+    }
+
     public static final long getScDirMask()
     {
         return scDirMask;

--- a/core/src/main/java/com/graphhopper/storage/index/BresenhamLine.java
+++ b/core/src/main/java/com/graphhopper/storage/index/BresenhamLine.java
@@ -30,8 +30,11 @@ package com.graphhopper.storage.index;
  */
 public class BresenhamLine
 {
-    public static void calcPoints( int y1, int x1, int y2, int x2,
-                                   PointEmitter emitter )
+    private BresenhamLine() {
+    }
+
+    public static void calcPoints(int y1, int x1, int y2, int x2,
+                                  PointEmitter emitter )
     {
         bresenham(y1, x1, y2, x2, emitter);
     }

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -38,6 +38,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class GHUtility
 {
+    private GHUtility() {
+    }
+
     /**
      * This method could throw exception if uncatched problems like index out of bounds etc
      */

--- a/core/src/main/java/com/graphhopper/util/Helper7.java
+++ b/core/src/main/java/com/graphhopper/util/Helper7.java
@@ -50,6 +50,9 @@ public class Helper7
         UNMAP_SUPPORTED = v;
     }
 
+    private Helper7() {
+    }
+
     public static String getBeanMemInfo()
     {
         java.lang.management.OperatingSystemMXBean mxbean = java.lang.management.ManagementFactory.getOperatingSystemMXBean();

--- a/core/src/main/java/com/graphhopper/util/NumHelper.java
+++ b/core/src/main/java/com/graphhopper/util/NumHelper.java
@@ -24,6 +24,9 @@ public class NumHelper
 {
     private final static double DEFAULT_PRECISION = 1e-6;
 
+    private NumHelper() {
+    }
+
     public static boolean equalsEps( double d1, double d2 )
     {
         return equalsEps(d1, d2, DEFAULT_PRECISION);

--- a/web/src/main/java/com/graphhopper/http/WebHelper.java
+++ b/web/src/main/java/com/graphhopper/http/WebHelper.java
@@ -36,7 +36,10 @@ import java.net.URLEncoder;
  */
 public class WebHelper
 {
-    public static String encodeURL( String str )
+    private WebHelper() {
+    }
+
+    public static String encodeURL(String str )
     {
         try
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
Please let me know if you have any questions.
Kirill Vlasov