### PR TITLE
Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/OSMElement.java
+++ b/core/src/main/java/com/graphhopper/reader/OSMElement.java
@@ -64,7 +64,7 @@ public abstract class OSMElement
                 String key = parser.getAttributeValue(null, "k");
                 String value = parser.getAttributeValue(null, "v");
                 // ignore tags with empty values
-                if (value != null && value.length() > 0)
+                if (value != null && !value.isEmpty())
                     setTag(key, value);
             }
 

--- a/core/src/main/java/com/graphhopper/reader/pbf/PbfBlobDecoder.java
+++ b/core/src/main/java/com/graphhopper/reader/pbf/PbfBlobDecoder.java
@@ -102,7 +102,7 @@ public class PbfBlobDecoder implements Runnable
         // We can't continue if there are any unsupported features. We wait
         // until now so that we can display all unsupported features instead of
         // just the first one we encounter.
-        if (unsupportedFeatures.size() > 0)
+        if (!unsupportedFeatures.isEmpty())
         {
             throw new RuntimeException("PBF file contains unsupported features " + unsupportedFeatures);
         }

--- a/core/src/main/java/com/graphhopper/routing/util/TestAlgoCollector.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TestAlgoCollector.java
@@ -138,7 +138,7 @@ public class TestAlgoCollector
 
     void printSummary()
     {
-        if (errors.size() > 0)
+        if (!errors.isEmpty())
         {
             System.out.println("\n-------------------------------\n");
             System.out.println(toString());

--- a/core/src/main/java/com/graphhopper/storage/MMapDataAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/MMapDataAccess.java
@@ -225,7 +225,7 @@ public class MMapDataAccess extends AbstractDataAccess
     @Override
     public boolean loadExisting()
     {
-        if (segments.size() > 0)
+        if (!segments.isEmpty())
             throw new IllegalStateException("already initialized");
 
         if (isClosed())

--- a/core/src/main/java/com/graphhopper/util/Helper.java
+++ b/core/src/main/java/com/graphhopper/util/Helper.java
@@ -284,7 +284,7 @@ public class Helper
 
     public static boolean isEmpty( String str )
     {
-        return str == null || str.trim().length() == 0;
+        return str == null || str.trim().isEmpty();
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/util/PointList.java
+++ b/core/src/main/java/com/graphhopper/util/PointList.java
@@ -429,7 +429,7 @@ public class PointList implements Iterable<GHPoint3D>, PointAccess
     {
         for (String latlon : str.split("\\["))
         {
-            if (latlon.trim().length() == 0)
+            if (latlon.trim().isEmpty())
                 continue;
 
             String ll[] = latlon.split(",");

--- a/web/src/main/java/com/graphhopper/http/GraphHopperServlet.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperServlet.java
@@ -105,7 +105,7 @@ public class GraphHopperServlet extends GHBaseServlet
             FlagEncoder algoVehicle = hopper.getEncodingManager().getEncoder(vehicleStr);
 
             GHRequest request;
-            if (favoredHeadings.size() > 0)
+            if (!favoredHeadings.isEmpty())
             {
                 // if only one favored heading is specified take as start heading
                 if (favoredHeadings.size() == 1)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
Please let me know if you have any questions.
Kirill Vlasov