### PR TITLE
"switch" statements should end with a "default" clause

### DIFF
--- a/android/app/src/main/java/com/graphhopper/android/MainActivity.java
+++ b/android/app/src/main/java/com/graphhopper/android/MainActivity.java
@@ -579,6 +579,8 @@ public class MainActivity extends Activity
                         + end.latitude + "," + end.longitude));
                 startActivity(intent);
                 break;
+            default:
+                break;
         }
         return true;
     }

--- a/core/src/main/java/com/graphhopper/reader/OSMInputFile.java
+++ b/core/src/main/java/com/graphhopper/reader/OSMInputFile.java
@@ -232,6 +232,8 @@ public class OSMInputFile implements Sink, Closeable
                         case 'r':
                             id = Long.parseLong(idStr);
                             return OSMRelation.create(id, parser);
+                        default:
+                            break;
                     }
                 }
             }

--- a/core/src/main/java/com/graphhopper/reader/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/OSMReader.java
@@ -320,6 +320,8 @@ public class OSMReader implements DataReader
                         }
                         processRelation((OSMRelation) item);
                         break;
+                    default:
+                        break;
                 }
                 if (++counter % 100000000 == 0)
                 {

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -469,6 +469,8 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
             case 3:
                 wayTypeName = tr.tr("way");
                 break;
+            default:
+                break;
         }
 
         if (pavementName.isEmpty())

--- a/core/src/main/java/com/graphhopper/util/Instruction.java
+++ b/core/src/main/java/com/graphhopper/util/Instruction.java
@@ -286,6 +286,8 @@ public class Instruction
                 case Instruction.TURN_SHARP_RIGHT:
                     dir = tr.tr("turn_sharp_right");
                     break;
+                default:
+                    break;
             }
             if (dir == null)
                 throw new IllegalStateException("Turn indication not found " + indi);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
Kirill Vlasov